### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/on-commit.yml
+++ b/.github/workflows/on-commit.yml
@@ -1,7 +1,10 @@
 name: on-commit
 
 on:  # yamllint disable-line rule:truthy
-  - push
+  branches:
+    - "**"
+  tags-ignore:
+    - "**"
 
 jobs:
 

--- a/.github/workflows/on-commit.yml
+++ b/.github/workflows/on-commit.yml
@@ -1,10 +1,11 @@
 name: on-commit
 
 on:  # yamllint disable-line rule:truthy
-  branches:
-    - "**"
-  tags-ignore:
-    - "**"
+  push:
+    branches:
+      - "**"
+    tags-ignore:
+      - "**"
 
 jobs:
 

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -3,6 +3,7 @@ name: on-release
 on:  # yamllint disable-line rule:truthy
   release:
     types:
+      - prereleased
       - released
 
 jobs:


### PR DESCRIPTION
1. Do not run `on-commit` when tags are pushed.
1. Run `on-release` for prereleases.