### PR TITLE
Replace “release” event with “push”

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -1,10 +1,11 @@
 name: on-release
 
 on:  # yamllint disable-line rule:truthy
-  release:
-    types:
-      - prereleased
-      - released
+  push:
+    branches-ignore:
+      - "**"
+    tags:
+      - "**"
 
 jobs:
   publish:


### PR DESCRIPTION
Call me petty, but I like seeing the `ref` in the Actions page.