### PR TITLE
Use arguments instead of environment variables

### DIFF
--- a/.github/workflows/on-commit.yml
+++ b/.github/workflows/on-commit.yml
@@ -66,6 +66,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: us-east-1
+      S3_BUCKET: hugoci-test-bucket-248eadwvcive
     needs:
       - build
     runs-on: ubuntu-20.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,8 @@ RUN gpg --verify /tmp/aws.zip.sig /tmp/aws.zip && \
     rm -rf /tmp/*                              && \
     aws --version
 
+ENV AWS_DEFAULT_REGION us-east-1
+
 COPY config/ /config
 COPY bin/    /usr/local/bin
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # cariad/hugo-ci
 
-`cariad/hugo-ci` is a Docker image for building, testing and deploying [Hugo](https://github.com/gohugoio/hugo) sites:
-
-`cariad/hugo-ci` will:
+`cariad/hugo-ci` is a Docker image for building, validating and deploying [Hugo](https://github.com/gohugoio/hugo) sites:
 
 1. **Build** your Hugo site from source.
 1. **Validate** your site with [github.com/gjtorikian/html-proofer](https://github.com/gjtorikian/html-proofer).
-1. (Optional) **Upload** to your S3 bucket.
-1. (Optional) Fix your files’ **HTTP headers** with [github.com/cariad/s3headersetter](https://github.com/cariad/s3headersetter).
+1. (Optional) **Deploy** to your S3 bucket.
+1. Fix your files’ **HTTP headers** with [github.com/cariad/s3headersetter](https://github.com/cariad/s3headersetter).
 
 **Building Hugo sites in GitHub? Check out my _Hugo CI_ GitHub Action: [github.com/cariad/hugo-ci-action](https://github.com/cariad/hugo-ci-action)**
 
@@ -17,13 +15,13 @@
 
 ### Arguments
 
-| Argument      | Description                               | Default value              | Example                                       |
-|---------------|-------------------------------------------|----------------------------|-----------------------------------------------|
-| `--public`    | Path _within the container_ to build to   | `/pub`                     | `--public /github/workspace/public`           |
-| `--s3-bucket` | S3 bucket to upload to                    | Empty; will not upload     | `--s3-bucket hugoci-test-bucket-248eadwvcive` |
-| `--s3-prefix` | S3 prefix to upload to                    | Empty; will upload to root | `--s3-prefix microsite`                       |
-| `--s3-region` | Region where the S3 bucket resides        | `us-east-1`                | `--s3-region eu-west-2`                       |
-| `--source`    | Path _within the container_ to build from | `/src`                     | `--source /github/workspace`                  |
+| Argument      | Description                               | Default     |
+|---------------|-------------------------------------------|-------------|
+| `--public`    | Path _within the container_ to build to   | `/pub`      |
+| `--s3-bucket` | S3 bucket to upload to                    | _No upload_ |
+| `--s3-prefix` | S3 prefix to upload to                    | _No prefix_ |
+| `--s3-region` | S3 bucket region                          | `us-east-1` |
+| `--source`    | Path _within the container_ to build from | `/src`      |
 
 ### Environment variables
 
@@ -36,7 +34,10 @@ If you opt to deploy your site to an S3 bucket, you can set some custom HTTP hea
 - `Cache-Control` prescribes how long a file should be cached. Images, for example, typically don’t change as often as HTML files, and so can be granted much longer cache durations to aid performance.
 - `Content-Type` prescribes the type of a file. S3 has a jolly good try at identifying _some_ file types, but it’s far from complete. At time of writing, for example, S3 did not identity `.woff` files as `font/woff2`.
 
-To set custom headers, refer to [github.com/cariad/s3headersetter](https://github.com/cariad/s3headersetter) for guidance to create an `s3headersetter` configuration file, then save it as `.s3headersetter.yml` in the root of your source project.
+To set custom HTTP headers:
+
+1. Refer to [github.com/cariad/s3headersetter](https://github.com/cariad/s3headersetter) to create an `s3headersetter` configuration file.
+1. Save your configuration file as `.s3headersetter.yml` in the root of your source project.
 
 If you don’t create `.s3headersetter.yml` then the following defaults will take effect:
 
@@ -46,41 +47,35 @@ If you don’t create `.s3headersetter.yml` then the following defaults will tak
 | `.css`       | `max-age=604800, public` | _Defer to S3_  |
 | `.woff2`     | _Defer to S3_            | `font/woff2`   |
 
-## Running in GitHub
+## Examples
 
-Check out my _Hugo CI_ GitHub Action: [github.com/cariad/hugo-ci-action](https://github.com/cariad/hugo-ci-action).
-
-## Running locally
-
-`cariad/hugo-ci` is great for building and testing your Hugo sites locally.
-
-For an easy life, I recommend:
-
-- Map your local source directory to `/src` in the container.
-- Map your local build directory to `/pub` in the container.
-
-This sample script will take the current working directory as the source, and the `public` subdirectory as the build destination:
+### Build and test your local development project
 
 ```bash
-#!/bin/bash -e
-
-src_dir="$(pwd)"
-pub_dir="$(pwd)/public"
-
-docker run                                            \
-  --mount "type=bind,source=${src_dir:?},target=/src" \
-  --mount "type=bind,source=${pub_dir:?},target=/pub" \
-  --rm                                                \
+docker run                                             \
+  --mount "type=bind,source=$(pwd),target=/src"        \
+  --mount "type=bind,source=$(pwd)/public,target=/pub" \
+  --rm                                                 \
   cariad/hugo-ci
 ```
 
-To run this script against your local development directory:
+### Build, test and upload your local development project
 
-1. Copy-paste the script into `test.sh`.
-1. Give the script permission to execute with `chmod +x test.sh`.
-1. Run it with `./test.sh`.
+```bash
+docker run                                                     \
+  --env       AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:?}         \
+  --env       AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:?} \
+  --mount     "type=bind,source=$(pwd),target=/workspace"      \
+  --rm                                                         \
+  cariad/hugo-ci                                               \
+  --source    /workspace                                       \
+  --public    /workspace/public                                \
+  --s3-bucket mybucket
+```
 
-The `public` directory should then contain your built website.
+### Build, test and upload your GitHub project
+
+Check out my _Hugo CI_ GitHub Action: [github.com/cariad/hugo-ci-action](https://github.com/cariad/hugo-ci-action).
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@
 
 ### Arguments
 
-| Argument      | Description                               | Default     |
-|---------------|-------------------------------------------|-------------|
-| `--public`    | Path _within the container_ to build to   | `/pub`      |
-| `--s3-bucket` | S3 bucket to upload to                    | _No upload_ |
-| `--s3-prefix` | S3 prefix to upload to                    | _No prefix_ |
-| `--s3-region` | S3 bucket region                          | `us-east-1` |
-| `--source`    | Path _within the container_ to build from | `/src`      |
+| Argument      | Description                               | Default      |
+|---------------|-------------------------------------------|--------------|
+| `--s3-bucket` | S3 bucket to upload to                    | _No upload_  |
+| `--s3-prefix` | S3 prefix to upload to                    | _No prefix_  |
+| `--s3-region` | S3 bucket region                          | `us-east-1`  |
+| `--workspace` | Path _within the container_ to build from | `/workspace` |
+
+The site will be built to the `public` directory of the workspace.
 
 ### Environment variables
 
@@ -52,10 +53,9 @@ If you don’t create `.s3headersetter.yml` then the following defaults will tak
 ### Build and test your local development project
 
 ```bash
-docker run                                             \
-  --mount "type=bind,source=$(pwd),target=/src"        \
-  --mount "type=bind,source=$(pwd)/public,target=/pub" \
-  --rm                                                 \
+docker run                                            \
+  --mount "type=bind,source=$(pwd),target=/workspace" \
+  --rm                                                \
   cariad/hugo-ci
 ```
 
@@ -68,8 +68,6 @@ docker run                                                     \
   --mount     "type=bind,source=$(pwd),target=/workspace"      \
   --rm                                                         \
   cariad/hugo-ci                                               \
-  --source    /workspace                                       \
-  --public    /workspace/public                                \
   --s3-bucket mybucket
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,19 +15,19 @@
 
 ## Configuration
 
+### Arguments
+
+| Argument      | Description                               | Default value              | Example                                       |
+|---------------|-------------------------------------------|----------------------------|-----------------------------------------------|
+| `--public`    | Path _within the container_ to build to   | `/pub`                     | `--public /github/workspace/public`           |
+| `--s3-bucket` | S3 bucket to upload to                    | Empty; will not upload     | `--s3-bucket hugoci-test-bucket-248eadwvcive` |
+| `--s3-prefix` | S3 prefix to upload to                    | Empty; will upload to root | `--s3-prefix microsite`                       |
+| `--s3-region` | Region where the S3 bucket resides        | `us-east-1`                | `--s3-region eu-west-2`                       |
+| `--source`    | Path _within the container_ to build from | `/src`                     | `--source /github/workspace`                  |
+
 ### Environment variables
 
-| Environment variable    | Default | Description                                    | Required                                                     |
-|-------------------------|---------|------------------------------------------------|--------------------------------------------------------------|
-| `AWS_ACCESS_KEY_ID`     |         | Access key ID for S3 upload authentication     | Only to upload and not running with an AWS instance profile  |
-| `AWS_DEFAULT_REGION`    |         | S3 bucket region                               | Only to upload                                               |
-| `AWS_SECRET_ACCESS_KEY` |         | Secret access key for S3 upload authentication | Only to upload and not running with an AWS instance profile  |
-| `AWS_SESSION_TOKEN`     |         | Session token S3 upload authentication         | Only to upload and authenticating with temporary credentials |
-| `DEPLOY`                | `1`     | Set to `0` to perform a dry-run                | Optional                                                     |
-| `PUBLIC`                | `/pub`  | Path to website build directory                | Optional                                                     |
-| `S3_BUCKET`             |         | Name of S3 bucket to upload to                 | Only to upload                                               |
-| `S3_PREFIX`             |         | S3 prefix to upload to                         | Only to upload to an S3 prefix                               |
-| `SOURCE`                | `/src`  | Path to website source files                   | Optional                                                     |
+`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and (if required) `AWS_SESSION_TOKEN` environment variables are required only when deploying to an S3 bucket.
 
 ### HTTP headers
 
@@ -46,6 +46,10 @@ If you don’t create `.s3headersetter.yml` then the following defaults will tak
 | `.css`       | `max-age=604800, public` | _Defer to S3_  |
 | `.woff2`     | _Defer to S3_            | `font/woff2`   |
 
+## Running in GitHub
+
+Check out my _Hugo CI_ GitHub Action: [github.com/cariad/hugo-ci-action](https://github.com/cariad/hugo-ci-action).
+
 ## Running locally
 
 `cariad/hugo-ci` is great for building and testing your Hugo sites locally.
@@ -53,7 +57,7 @@ If you don’t create `.s3headersetter.yml` then the following defaults will tak
 For an easy life, I recommend:
 
 - Map your local source directory to `/src` in the container.
-- Map your local build directory to `/pub` in the container. This directory must exist.
+- Map your local build directory to `/pub` in the container.
 
 This sample script will take the current working directory as the source, and the `public` subdirectory as the build destination:
 
@@ -62,9 +66,6 @@ This sample script will take the current working directory as the source, and th
 
 src_dir="$(pwd)"
 pub_dir="$(pwd)/public"
-
-rm -rf "${pub_dir:?}"
-mkdir  "${pub_dir:?}"
 
 docker run                                            \
   --mount "type=bind,source=${src_dir:?},target=/src" \
@@ -79,34 +80,7 @@ To run this script against your local development directory:
 1. Give the script permission to execute with `chmod +x test.sh`.
 1. Run it with `./test.sh`.
 
-You should see a response like this:
-
-```text
-Start building sites …
-
-                   | EN
--------------------+------
-  Pages            |  22
-  Paginator pages  |   0
-  Non-page files   |   6
-  Static files     |  48
-  Processed images | 139
-  Aliases          |   1
-  Sitemaps         |   1
-  Cleaned          |   0
-
-Total in 3343 ms
-Proofing...
-Running ["ScriptCheck", "OpenGraphCheck", "ImageCheck", "HtmlCheck", "FaviconCheck", "LinkCheck"] on ["/pub"] on *.html...
-
-
-Ran on 15 files!
-
-
-HTML-Proofer finished successfully.
-```
-
-…and the `public` directory should contain your built website.
+The `public` directory should then contain your built website.
 
 ## Acknowledgements
 

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -35,33 +35,35 @@ done
 # Resolve defaults:
 
 if [ -z "${workspace}" ]; then
-  src=/workspace
+  workspace=/workspace
   echo -e "${li:?}Workspace: ${workspace:?} (default)"
 else
   echo -e "${li:?}Workspace: ${workspace:?}"
 fi
 
-echo -e "${li:?}Region:      ${AWS_DEFAULT_REGION:?}"
+public="${workspace:?}/public"
+echo -e "${li:?}Public:    ${public:?}"
+echo -e "${li:?}Region:    ${AWS_DEFAULT_REGION:?}"
 
 # Build:
 
-hugo --source "${workspace:?}" --minify
+hugo --source "${workspace:?}" --destination "${public:?}" --minify
 
 # Lint:
 
 echo -e "${li:?}Linting…"
-htmlproofer "${pub:?}"      \
-  --allow-hash-href         \
-  --check-favicon           \
-  --check-html              \
-  --check-img-http          \
-  --check-opengraph         \
-  --disable-external        \
-  --report-invalid-tags     \
-  --report-missing-names    \
-  --report-script-embeds    \
-  --report-missing-doctype  \
-  --report-eof-tags         \
+htmlproofer "${public:?}"  \
+  --allow-hash-href        \
+  --check-favicon          \
+  --check-html             \
+  --check-img-http         \
+  --check-opengraph        \
+  --disable-external       \
+  --report-invalid-tags    \
+  --report-missing-names   \
+  --report-script-embeds   \
+  --report-missing-doctype \
+  --report-eof-tags        \
   --report-mismatched-tags
 
 echo -e "${ok:?} OK"
@@ -107,7 +109,7 @@ echo -e "${li:?}s3headersetter arguments: ${header_args[*]}"
 # Upload:
 
 echo -e "${li:?}Uploading…"
-aws s3 sync --delete "${pub:?}" "${s3_path:?}"
+aws s3 sync --delete "${public:?}" "${s3_path:?}"
 
 # Set HTTP headers:
 

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -48,7 +48,7 @@ htmlproofer "${pub:?}"      \
 
 echo -e "${ok:?} OK"
 
-if [ -n "${s3_bucket}" ]; then
+if [ -z "${s3_bucket}" ]; then
   exit 0
 fi
 

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -3,10 +3,30 @@
 li="\033[1;34m•\033[0m "  # List item
 ok="\033[0;32m✔️\033[0m "  # OK
 
-src=${SOURCE:=/src}
-echo -e "${li:?}Source path: ${src:?}"
+src=/src
+pub=/pub
 
-pub=${PUBLIC:=/pub}
+while [[ $1 = -* ]]; do
+  arg=$1; shift
+
+  case ${arg} in
+    --public)
+      pub=${1:?}; shift;;
+
+    --s3_bucket)
+      s3_bucket=${1:?}; shift;;
+
+    --source)
+      src=${1:?}; shift;;
+
+    *)
+      echo "Unexpected argument: ${arg}"
+      exit 1
+      ;;
+  esac
+done
+
+echo -e "${li:?}Source path: ${src:?}"
 echo -e "${li:?}Public path: ${pub:?}"
 
 hugo --source "${src:?}" --destination "${pub:?}" --minify
@@ -28,21 +48,21 @@ htmlproofer "${pub:?}"      \
 
 echo -e "${ok:?} OK"
 
-if [ "${S3_BUCKET:=}" == "" ]; then
+if [ -n ${s3_bucket} ]; then
   exit 0
 fi
 
-echo -e "${li:?}S3 bucket: ${S3_BUCKET:?}"
-s3_path="s3://${S3_BUCKET:?}"
+echo -e "${li:?}S3 bucket: ${s3_bucket:?}"
+s3_path="s3://${s3_bucket:?}"
 
 if [ "${S3_PREFIX:=}" != "" ]; then
   echo -e "${li:?}S3 prefix: ${S3_PREFIX:=}"
-  s3_path="s3://${S3_BUCKET:?}/${S3_PREFIX:?}"
+  s3_path="s3://${s3_bucket:?}/${S3_PREFIX:?}"
 fi
 
 echo -e "${li:?}S3 path: ${s3_path:?}"
 
-header_args=(-bucket "${S3_BUCKET:?}")
+header_args=(-bucket "${s3_bucket:?}")
 
 usr_header_config="${src:?}/.s3headersetter.yml"
 sys_header_config=/config/.s3headersetter.yml

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -5,19 +5,14 @@
 li="\033[1;34m•\033[0m "  # List item
 ok="\033[0;32m✔️\033[0m "  # OK
 
-# Default values:
-
-src=/src
-pub=/pub
-
 # Read command line arguments:
 
 while [[ $1 = -* ]]; do
   arg=$1; shift
 
   case ${arg} in
-    --public)
-      pub=${1:?}; shift;;
+    --workspace)
+      workspace=${1:?}; shift;;
 
     --s3-bucket)
       s3_bucket=${1:?}; shift;;
@@ -30,9 +25,6 @@ while [[ $1 = -* ]]; do
       export AWS_DEFAULT_REGION
       shift;;
 
-    --source)
-      src=${1:?}; shift;;
-
     *)
       echo "Unexpected argument: ${arg}"
       exit 1
@@ -40,15 +32,20 @@ while [[ $1 = -* ]]; do
   esac
 done
 
-# Log the values we'll run with:
+# Resolve defaults:
 
-echo -e "${li:?}Source path: ${src:?}"
-echo -e "${li:?}Public path: ${pub:?}"
+if [ -z "${workspace}" ]; then
+  src=/workspace
+  echo -e "${li:?}Workspace: ${workspace:?} (default)"
+else
+  echo -e "${li:?}Workspace: ${workspace:?}"
+fi
+
 echo -e "${li:?}Region:      ${AWS_DEFAULT_REGION:?}"
 
 # Build:
 
-hugo --source "${src:?}" --destination "${pub:?}" --minify
+hugo --source "${workspace:?}" --minify
 
 # Lint:
 

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -48,7 +48,7 @@ htmlproofer "${pub:?}"      \
 
 echo -e "${ok:?} OK"
 
-if [ -n ${s3_bucket} ]; then
+if [ -n "${s3_bucket}" ]; then
   exit 0
 fi
 

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -91,7 +91,7 @@ echo -e "${li:?}S3 path: ${s3_path:?}"
 
 header_args=(-bucket "${s3_bucket:?}")
 
-usr_header_config="${src:?}/.s3headersetter.yml"
+usr_header_config="${workspace:?}/.s3headersetter.yml"
 sys_header_config=/config/.s3headersetter.yml
 
 if [ -f "${usr_header_config}" ]; then

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -25,6 +25,11 @@ while [[ $1 = -* ]]; do
     --s3-prefix)
       s3_prefix=${1:?}; shift;;
 
+    --s3-region)
+      AWS_DEFAULT_REGION=${1:?}
+      export AWS_DEFAULT_REGION
+      shift;;
+
     --source)
       src=${1:?}; shift;;
 
@@ -39,6 +44,7 @@ done
 
 echo -e "${li:?}Source path: ${src:?}"
 echo -e "${li:?}Public path: ${pub:?}"
+echo -e "${li:?}Region:      ${AWS_DEFAULT_REGION:?}"
 
 # Build:
 

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -107,13 +107,6 @@ fi
 
 echo -e "${li:?}s3headersetter arguments: ${header_args[*]}"
 
-# If this is a dry-run then stop now:
-
-if [ "${DEPLOY:=0}" == "1" ]; then
-  echo "This is a dry-run, so gracefully stopping now."
-  exit 0
-fi
-
 # Upload:
 
 echo -e "${li:?}Uploading…"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
     volumes:
       - .:/src
-      - ./public:/pub
+      - ./public-uploaded:/pub
 
   upload_with_prefix:
     command: >-
@@ -43,4 +43,4 @@ services:
       - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
     volumes:
       - .:/src
-      - ./public:/pub
+      - ./public-uploaded-with-prefix:/pub

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,33 +13,32 @@ services:
     volumes:
       - .:/workspace
 
+  # Maps the "sub-workspace" directory to the default workspace.
+  # Builds to "sub-workspace/public".
+  sub-workspace:
+    image: cariad/hugo-ci:${BRANCH}
+    volumes:
+      - ./sub-workspace:/workspace
+
   # Maps the "alt-workspace" directory to the "/alt-workspace" workspace.
   # Builds to "alt-workspace/public".
   alt-workspace:
-    command: >-
-      --workspace /alt-workspace
+    command: --workspace /alt-workspace
     image: cariad/hugo-ci:${BRANCH}
     volumes:
       - ./alt-workspace:/alt-workspace
 
-  # subdirectory:
-  #   image: cariad/hugo-ci:${BRANCH}
-  #   volumes:
-  #     - ./subdirectory:/src
-  #     - ./subdirectory/public:/pub
-
-  # upload:
-  #   command: >-
-  #     --s3-bucket ${S3_BUCKET}
-  #     --s3-region ${AWS_DEFAULT_REGION}
-
-  #   image: cariad/hugo-ci:${BRANCH}
-  #   environment:
-  #     - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-  #     - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-  #   volumes:
-  #     - .:/src
-  #     - ./public-uploaded:/pub
+  # Maps the "upload-workspace" directory to the default workspace.
+  # Builds to "upload-workspace/public".
+  # This test should be verified by downloading the root content of the bucket.
+  upload:
+    command: --s3-bucket ${S3_BUCKET}
+    environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    image: cariad/hugo-ci:${BRANCH}
+    volumes:
+      - ./upload-workspace:/workspace
 
   # upload_with_prefix:
   #   command: >-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,15 +40,14 @@ services:
     volumes:
       - ./upload-workspace:/workspace
 
-  # upload_with_prefix:
-  #   command: >-
-  #     --s3-bucket ${S3_BUCKET}
-  #     --s3-prefix ${GITHUB_SHA}
-
-  #   image: cariad/hugo-ci:${BRANCH}
-  #   environment:
-  #     - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-  #     - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-  #   volumes:
-  #     - .:/src
-  #     - ./public-uploaded-with-prefix:/pub
+  # Maps the "upload-with-prefix-workspace" directory to the default workspace.
+  # Builds to "upload-with-prefix-workspace/public".
+  # This test should be verified by downloading the prefix content of the bucket.
+  upload-with-prefix:
+    command: --s3-bucket ${S3_BUCKET} --s3-prefix ${GITHUB_SHA}
+    environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    image: cariad/hugo-ci:${BRANCH}
+    volumes:
+      - ./upload-with-prefix-workspace:/workspace

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,26 @@
+# Runs a collection of test scenarios.
+#
+# Assumes that the test data has already been arranged!
+
 version: "3.9"
 
 services:
 
+  # Maps the working directory to the default workspace.
+  # Builds to "public".
   root:
     image: cariad/hugo-ci:${BRANCH}
     volumes:
       - .:/workspace
 
-  alt-src:
+  # Maps the "alt-workspace" directory to the "/alt-workspace" workspace.
+  # Builds to "alt-workspace/public".
+  alt-workspace:
     command: >-
-      --workspace /alt-src
+      --workspace /alt-workspace
     image: cariad/hugo-ci:${BRANCH}
     volumes:
-      - ./alt-src:/alt-src
-
-  alt-pub:
-    command: >-
-      --workspace /alt-pub
-    image: cariad/hugo-ci:${BRANCH}
-    volumes:
-      - ./.:/workspace
-      - ./alt-pub:/alt-pub
+      - ./alt-workspace:/alt-workspace
 
   # subdirectory:
   #   image: cariad/hugo-ci:${BRANCH}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,47 +9,47 @@ services:
 
   alt-src:
     command: >-
-      --source /alt-src
+      --workspace /alt-src
     image: cariad/hugo-ci:${BRANCH}
     volumes:
       - ./alt-src:/alt-src
 
   alt-pub:
     command: >-
-      --public /alt-pub
+      --workspace /alt-pub
     image: cariad/hugo-ci:${BRANCH}
     volumes:
       - ./.:/workspace
       - ./alt-pub:/alt-pub
 
-  subdirectory:
-    image: cariad/hugo-ci:${BRANCH}
-    volumes:
-      - ./subdirectory:/src
-      - ./subdirectory/public:/pub
+  # subdirectory:
+  #   image: cariad/hugo-ci:${BRANCH}
+  #   volumes:
+  #     - ./subdirectory:/src
+  #     - ./subdirectory/public:/pub
 
-  upload:
-    command: >-
-      --s3-bucket ${S3_BUCKET}
-      --s3-region ${AWS_DEFAULT_REGION}
+  # upload:
+  #   command: >-
+  #     --s3-bucket ${S3_BUCKET}
+  #     --s3-region ${AWS_DEFAULT_REGION}
 
-    image: cariad/hugo-ci:${BRANCH}
-    environment:
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-    volumes:
-      - .:/src
-      - ./public-uploaded:/pub
+  #   image: cariad/hugo-ci:${BRANCH}
+  #   environment:
+  #     - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+  #     - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+  #   volumes:
+  #     - .:/src
+  #     - ./public-uploaded:/pub
 
-  upload_with_prefix:
-    command: >-
-      --s3-bucket ${S3_BUCKET}
-      --s3-prefix ${GITHUB_SHA}
+  # upload_with_prefix:
+  #   command: >-
+  #     --s3-bucket ${S3_BUCKET}
+  #     --s3-prefix ${GITHUB_SHA}
 
-    image: cariad/hugo-ci:${BRANCH}
-    environment:
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-    volumes:
-      - .:/src
-      - ./public-uploaded-with-prefix:/pub
+  #   image: cariad/hugo-ci:${BRANCH}
+  #   environment:
+  #     - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+  #     - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+  #   volumes:
+  #     - .:/src
+  #     - ./public-uploaded-with-prefix:/pub

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
 
   # Maps the "upload-workspace" directory to the default workspace.
   # Builds to "upload-workspace/public".
-  # This test should be verified by downloading the root content of the bucket.
+  # Verify by downloading the root content of the bucket.
   upload:
     command: --s3-bucket ${S3_BUCKET}
     environment:
@@ -42,7 +42,7 @@ services:
 
   # Maps the "upload-with-prefix-workspace" directory to the default workspace.
   # Builds to "upload-with-prefix-workspace/public".
-  # This test should be verified by downloading the prefix content of the bucket.
+  # Verify by downloading the prefix content of the bucket.
   upload-with-prefix:
     command: --s3-bucket ${S3_BUCKET} --s3-prefix ${GITHUB_SHA}
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - ./subdirectory/public:/pub
 
   upload:
-    command: --s3_bucket hugoci-test-bucket-248eadwvcive
+    command: --s3-bucket hugoci-test-bucket-248eadwvcive
     image: cariad/hugo-ci:${BRANCH}
     environment:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
@@ -33,13 +33,14 @@ services:
       - ./public:/pub
 
   upload_with_prefix:
-    command: --s3_bucket hugoci-test-bucket-248eadwvcive
+    command: >-
+      --s3-bucket hugoci-test-bucket-248eadwvcive
+      --s3-prefix ${GITHUB_SHA}
     image: cariad/hugo-ci:${BRANCH}
     environment:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
-      - S3_PREFIX=${GITHUB_SHA}
     volumes:
       - .:/src
       - ./public:/pub

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,10 @@ services:
       - ./public:/pub
 
   root_custom_path:
-    command: --public /custom-pub --source /custom-src
+    command: >-
+      --public /custom-pub
+      --source /custom-src
+
     image: cariad/hugo-ci:${BRANCH}
     volumes:
       - ./:/custom-src
@@ -22,25 +25,27 @@ services:
       - ./subdirectory/public:/pub
 
   upload:
-    command: --s3-bucket hugoci-test-bucket-248eadwvcive
+    command: >-
+      --s3-bucket ${S3_BUCKET}
+      --s3-region ${AWS_DEFAULT_REGION}
+
     image: cariad/hugo-ci:${BRANCH}
     environment:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
     volumes:
       - .:/src
       - ./public-uploaded:/pub
 
   upload_with_prefix:
     command: >-
-      --s3-bucket hugoci-test-bucket-248eadwvcive
+      --s3-bucket ${S3_BUCKET}
       --s3-prefix ${GITHUB_SHA}
+
     image: cariad/hugo-ci:${BRANCH}
     environment:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
     volumes:
       - .:/src
       - ./public-uploaded-with-prefix:/pub

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,13 @@ services:
       - .:/src
       - ./public:/pub
 
+   root_custom_path:
+    command: --public /custom-pub --source /custom-src
+    image: cariad/hugo-ci:${BRANCH}
+    volumes:
+      - ./:/custom-src
+      - ./custom-public:/custom-pub
+
   subdirectory:
     image: cariad/hugo-ci:${BRANCH}
     volumes:
@@ -15,23 +22,23 @@ services:
       - ./subdirectory/public:/pub
 
   upload:
+    command: --s3_bucket hugoci-test-bucket-248eadwvcive
     image: cariad/hugo-ci:${BRANCH}
     environment:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
-      - S3_BUCKET=hugoci-test-bucket-248eadwvcive
     volumes:
       - .:/src
       - ./public:/pub
 
   upload_with_prefix:
+    command: --s3_bucket hugoci-test-bucket-248eadwvcive
     image: cariad/hugo-ci:${BRANCH}
     environment:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
-      - S3_BUCKET=hugoci-test-bucket-248eadwvcive
       - S3_PREFIX=${GITHUB_SHA}
     volumes:
       - .:/src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - .:/src
       - ./public:/pub
 
-   root_custom_path:
+  root_custom_path:
     command: --public /custom-pub --source /custom-src
     image: cariad/hugo-ci:${BRANCH}
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,18 +5,22 @@ services:
   root:
     image: cariad/hugo-ci:${BRANCH}
     volumes:
-      - .:/src
-      - ./public:/pub
+      - .:/workspace
 
-  root_custom_path:
+  alt-src:
     command: >-
-      --public /custom-pub
-      --source /custom-src
-
+      --source /alt-src
     image: cariad/hugo-ci:${BRANCH}
     volumes:
-      - ./:/custom-src
-      - ./custom-public:/custom-pub
+      - ./alt-src:/alt-src
+
+  alt-pub:
+    command: >-
+      --public /alt-pub
+    image: cariad/hugo-ci:${BRANCH}
+    volumes:
+      - ./.:/workspace
+      - ./alt-pub:/alt-pub
 
   subdirectory:
     image: cariad/hugo-ci:${BRANCH}

--- a/test-image.sh
+++ b/test-image.sh
@@ -4,8 +4,6 @@ li="\033[1;34m•\033[0m "  # List item
 nk="\033[0;31m⨯\033[0m "  # Not OK
 ok="\033[0;32m✔️\033[0m "  # OK
 
-bucket=hugoci-test-bucket-248eadwvcive
-
 echo -e "${li:?}Arranging tests…"
 echo 'title = "My New Hugo Site"' > config.toml
 mkdir subdirectory
@@ -14,7 +12,7 @@ echo 'title = "My New Hugo Site"' > subdirectory/config.toml
 ref="${GITHUB_REF:?}"
 branch="${ref##*/}"
 
-aws s3 rm "s3://${bucket:?}" --recursive
+aws s3 rm "s3://${S3_BUCKET:?}" --recursive
 
 echo -e "${li:?}Starting containers…"
 BRANCH="${branch:?}" docker-compose up
@@ -40,16 +38,13 @@ verify public
 verify custom-public
 verify subdirectory/public
 
-bucket=hugoci-test-bucket-248eadwvcive
-
-aws s3 sync "s3://${bucket:?}/${GITHUB_SHA:?}" ./uploaded-with-prefix
+aws s3 sync "s3://${S3_BUCKET:?}/${GITHUB_SHA:?}" ./uploaded-with-prefix
 verify uploaded-with-prefix
-aws s3 rm "s3://${bucket:?}/${GITHUB_SHA:?}" --recursive
+aws s3 rm "s3://${S3_BUCKET:?}/${GITHUB_SHA:?}" --recursive
 
-aws s3 sync "s3://${bucket:?}" ./uploaded-root
+aws s3 sync "s3://${S3_BUCKET:?}" ./uploaded-root
 verify uploaded-root
 
-# I intentionally don't erase this "root" deployment so I can check the HTTP
-# headers.
+# Don't erase this "root" deployment; go check the HTTP headers.
 
 echo -e "${ok:?}OK!"

--- a/test-image.sh
+++ b/test-image.sh
@@ -37,6 +37,7 @@ function verify() {
 }
 
 verify public
+verify custom-public
 verify subdirectory/public
 
 bucket=hugoci-test-bucket-248eadwvcive

--- a/test-image.sh
+++ b/test-image.sh
@@ -11,8 +11,8 @@ function make_source() {
   echo 'title = "My New Hugo Site"' > "${1:?}/config.toml"
 }
 
-make_source .        # "root" scenario; expect "public"
-make_source alt-src  # "alt-src" scenario; expect "alt-src/public"
+make_source .
+make_source alt-workspace
 
 
 ref="${GITHUB_REF:?}"
@@ -40,9 +40,8 @@ function verify() {
   echo -e "${ok:?}${1:?} OK"
 }
 
-verify public          # "root" scenario
-verify alt-src/public  # "alt-src" scenario
-verify alt-pub         # "alt-pub" scenario
+verify public                # "root" scenario
+verify alt-workspace/public  # "alt-workspace" scenario
 
 # verify custom-public
 # verify subdirectory/public

--- a/test-image.sh
+++ b/test-image.sh
@@ -15,7 +15,7 @@ make_source .
 make_source sub-workspace
 make_source alt-workspace
 make_source upload-workspace
-
+make_source upload-with-prefix-workspace
 
 ref="${GITHUB_REF:?}"
 branch="${ref##*/}"
@@ -42,14 +42,13 @@ function verify() {
   echo -e "${ok:?}${1:?} OK"
 }
 
-verify public                # "root" scenario
-verify sub-workspace/public  # "sub-workspace" scenario
-verify alt-workspace/public  # "alt-workspace" scenario
+verify public
+verify sub-workspace/public
+verify alt-workspace/public
 
-
-# aws s3 sync "s3://${S3_BUCKET:?}/${GITHUB_SHA:?}" ./public-with-prefix
-# verify public-with-prefix
-# aws s3 rm "s3://${S3_BUCKET:?}/${GITHUB_SHA:?}" --recursive
+aws s3 sync "s3://${S3_BUCKET:?}/${GITHUB_SHA:?}" ./upload-with-prefix-public
+verify upload-with-prefix-public
+aws s3 rm "s3://${S3_BUCKET:?}/${GITHUB_SHA:?}" --recursive
 
 aws s3 sync "s3://${S3_BUCKET:?}" ./upload-public
 verify upload-public

--- a/test-image.sh
+++ b/test-image.sh
@@ -42,8 +42,8 @@ verify subdirectory/public
 
 bucket=hugoci-test-bucket-248eadwvcive
 
-aws s3 sync "s3://${bucket:?}/${GITHUB_SHA:?}" ./uploaded-subdirectory
-verify uploaded-subdirectory
+aws s3 sync "s3://${bucket:?}/${GITHUB_SHA:?}" ./uploaded-with-prefix
+verify uploaded-with-prefix
 aws s3 rm "s3://${bucket:?}/${GITHUB_SHA:?}" --recursive
 
 aws s3 sync "s3://${bucket:?}" ./uploaded-root

--- a/test-image.sh
+++ b/test-image.sh
@@ -12,7 +12,9 @@ function make_source() {
 }
 
 make_source .
+make_source sub-workspace
 make_source alt-workspace
+make_source upload-workspace
 
 
 ref="${GITHUB_REF:?}"
@@ -41,17 +43,16 @@ function verify() {
 }
 
 verify public                # "root" scenario
+verify sub-workspace/public  # "sub-workspace" scenario
 verify alt-workspace/public  # "alt-workspace" scenario
 
-# verify custom-public
-# verify subdirectory/public
 
 # aws s3 sync "s3://${S3_BUCKET:?}/${GITHUB_SHA:?}" ./public-with-prefix
 # verify public-with-prefix
 # aws s3 rm "s3://${S3_BUCKET:?}/${GITHUB_SHA:?}" --recursive
 
-# aws s3 sync "s3://${S3_BUCKET:?}" ./uploaded-root
-# verify uploaded-root
+aws s3 sync "s3://${S3_BUCKET:?}" ./upload-public
+verify upload-public
 
 # Don't erase this "root" deployment; go check the HTTP headers.
 

--- a/test-image.sh
+++ b/test-image.sh
@@ -5,9 +5,15 @@ nk="\033[0;31m⨯\033[0m "  # Not OK
 ok="\033[0;32m✔️\033[0m "  # OK
 
 echo -e "${li:?}Arranging tests…"
-echo 'title = "My New Hugo Site"' > config.toml
-mkdir subdirectory
-echo 'title = "My New Hugo Site"' > subdirectory/config.toml
+
+function make_source() {
+  mkdir -p "${1:?}"
+  echo 'title = "My New Hugo Site"' > "${1:?}/config.toml"
+}
+
+make_source .        # "root" scenario; expect "public"
+make_source alt-src  # "alt-src" scenario; expect "alt-src/public"
+
 
 ref="${GITHUB_REF:?}"
 branch="${ref##*/}"
@@ -34,16 +40,19 @@ function verify() {
   echo -e "${ok:?}${1:?} OK"
 }
 
-verify public
-verify custom-public
-verify subdirectory/public
+verify public          # "root" scenario
+verify alt-src/public  # "alt-src" scenario
+verify alt-pub         # "alt-pub" scenario
 
-aws s3 sync "s3://${S3_BUCKET:?}/${GITHUB_SHA:?}" ./uploaded-with-prefix
-verify uploaded-with-prefix
-aws s3 rm "s3://${S3_BUCKET:?}/${GITHUB_SHA:?}" --recursive
+# verify custom-public
+# verify subdirectory/public
 
-aws s3 sync "s3://${S3_BUCKET:?}" ./uploaded-root
-verify uploaded-root
+# aws s3 sync "s3://${S3_BUCKET:?}/${GITHUB_SHA:?}" ./public-with-prefix
+# verify public-with-prefix
+# aws s3 rm "s3://${S3_BUCKET:?}/${GITHUB_SHA:?}" --recursive
+
+# aws s3 sync "s3://${S3_BUCKET:?}" ./uploaded-root
+# verify uploaded-root
 
 # Don't erase this "root" deployment; go check the HTTP headers.
 


### PR DESCRIPTION
It _looks_ like GitHub actions always passes workflow environment variables through to containers.

I'd prefer to make the state a little more explicit.